### PR TITLE
Fixed a minor typo

### DIFF
--- a/_docs/applications/redis.md
+++ b/_docs/applications/redis.md
@@ -26,7 +26,7 @@ starting, ensure you have StorageOS installed on a cluster (refer to the
 
 1. Create a 1GB volume called `redis-data` in the default namespace.
 ```bash
-$ docker volume create --driver storageos --opt size=1 mysqldata
+$ docker volume create --driver storageos --opt size=1 redis-data
 redis-data
 $ docker volume list
 DRIVER              VOLUME NAME


### PR DESCRIPTION
The command to create the docker volume for redis in the guide
for using redis with StorageOS named the volume `mysqldata`
whereas the rest of the guide referred to the volume by the name
`redis-data`. This instance of `mysqldata` has been renamed as
appropriate.