### PR TITLE
Fix typo in the swagger spec for unmounting volumes

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -725,7 +725,7 @@ paths:
             $ref: "#/definitions/ErrorResponse"
   /namespaces/{namespace}/volumes/{name}/unmount:
     post:
-      summary: "Mount volume"
+      summary: "Unmount volume"
       description: "Updates the mount reference for the volume."
       produces:
         - "application/json"
@@ -735,7 +735,7 @@ paths:
         - $ref: "#/parameters/Namespace"
         - name: "client"
           in: "body"
-          description: "Hostname of the client mounting the volume"
+          description: "Hostname of the client unmounting the volume"
           required: true
           schema:
             type: "string"


### PR DESCRIPTION
Currently both `/namespaces/{namespace}/volumes/{name}/mount` and `/namespaces/{namespace}/volumes/{name}/unmount` are listed as being the "Mount volume" endpoint, with the request body being "Hostname of the client mounting the volume", despite one endpoint mounting and the other unmounting volumes.

