### PR TITLE
Add note about mount propagation in k8s 1.7

### DIFF
--- a/_docs/install/kubernetes.md
+++ b/_docs/install/kubernetes.md
@@ -7,8 +7,6 @@ module: install/kubernetes
 
 # Kubernetes
 
->**Note**: Native support for StorageOS volumes has been added in Kubernetes 1.7, which is the minimum requirement.
-
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
 - [Examples](#examples)
@@ -28,6 +26,8 @@ At its core, StorageOS provides block storage.  You may choose the filesystem ty
 ## Prerequisites
 
 The StorageOS container must be running on each node that wants to contribute storage or that wants to consume storage.  Currently this may be done as a standard Docker container (see [Docker Application Container](container.html)), that runs outside of Kubernetes control.
+
+Kubernetes 1.7+ is required.
 
 >**Note**: It is not currently possible to run the StorageOS container via Kubernetes in a Pod or Daemonset.  StorageOS and other containerized storage providers require that mount propagation be enabled using the `rshared` mount flag.  The [containerized mount feature](https://github.com/kubernetes/community/pull/589) is planned for Kubernetes 1.8, and is being developed in [PR #46444](https://github.com/kubernetes/kubernetes/pull/46444).  For Kubernetes 1.7, run the StorageOS container directly in Docker on each node, following the instructions at [Docker Application Container](container.html).
 

--- a/_docs/install/kubernetes.md
+++ b/_docs/install/kubernetes.md
@@ -7,10 +7,7 @@ module: install/kubernetes
 
 # Kubernetes
 
->**Note**: Full Kubernetes integration has been submitted for inclusion in Kubernetes 1.7.  You can
-track progress at [https://github.com/kubernetes/kubernetes/pull/42156](https://github.com/kubernetes/kubernetes/pull/42156).  Once approved and merged
-into Kubernetes, StorageOS will be available as a storage provider in the base Kubernetes distribution.  Until then,
-you must re-compile Kubernetes if you wish to test StorageOS integration with Kubernetes.
+>**Note**: Native support for StorageOS volumes has been added in Kubernetes 1.7, which is the minimum requirement.
 
 - [Overview](#overview)
 - [Prerequisites](#prerequisites)
@@ -30,7 +27,9 @@ At its core, StorageOS provides block storage.  You may choose the filesystem ty
 
 ## Prerequisites
 
-The StorageOS container must be running on each node that wants to contribute storage or that wants to consume storage.  This may be done as a DaemonSet or as a standard Docker container (see [Docker Application Container](container.html))
+The StorageOS container must be running on each node that wants to contribute storage or that wants to consume storage.  Currently this may be done as a standard Docker container (see [Docker Application Container](container.html)), that runs outside of Kubernetes control.
+
+>**Note**: It is not currently possible to run the StorageOS container via Kubernetes in a Pod or Daemonset.  StorageOS and other containerized storage providers require that mount propagation be enabled using the `rshared` mount flag.  The [containerized mount feature](https://github.com/kubernetes/community/pull/589) is planned for Kubernetes 1.8, and is being developed in [PR #46444](https://github.com/kubernetes/kubernetes/pull/46444).  For Kubernetes 1.7, run the StorageOS container directly in Docker on each node, following the instructions at [Docker Application Container](container.html).
 
 ## Examples
 


### PR DESCRIPTION
StorageOS now supported natively in k8s 1.7.  Add note to explain why we can not yet run as a daemonset.