### PR TITLE
Reintroduce redoc tags removed by bad merge

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -55,6 +55,14 @@ tags:
     x-displayName: "Pools"
     description: |
       Create and manage distributed capacity pools.
+  - name: "Rule"
+    x-displayName: "Rules"
+    description: |
+      Create and manage rules.
+  - name: "CapacityStat"
+    x-displayName: "CapacityStats"
+    description: |
+      Create and manage capacity statistics.
 
 definitions:
 


### PR DESCRIPTION
This is a commit cherry-picked from my other PR which isolates the fix for the API documentation