### PR TITLE
DEV-1816: Document separate error report disable variable

### DIFF
--- a/INSTALL_STORE_CONTAINER.md
+++ b/INSTALL_STORE_CONTAINER.md
@@ -138,3 +138,4 @@ Although the default settings should work for most environments, a number of set
 - `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`. Defaults to `info`.
 - `LOG_FORMAT`: Logging output format, one of `text` or `json`. Defaults to `json`.
 - `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+- `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.

--- a/INSTALL_STORE_PLUGIN.md
+++ b/INSTALL_STORE_PLUGIN.md
@@ -125,3 +125,4 @@ Although the default settings should work for most environments, a number of set
 - `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`. Defaults to `info`.
 - `LOG_FORMAT`: Logging output format, one of `text` or `json`. Defaults to `json`.
 - `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+- `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.

--- a/README_HUB_CONTAINER.md
+++ b/README_HUB_CONTAINER.md
@@ -131,3 +131,4 @@ Although the default settings should work for most environments, a number of set
 * `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`. Defaults to `info`.
 * `LOG_FORMAT`: Logging output format, one of `text` or `json`. Defaults to `json`.
 * `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+* `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.

--- a/README_HUB_PLUGIN.md
+++ b/README_HUB_PLUGIN.md
@@ -116,3 +116,4 @@ Although the default settings should work for most environments, a number of set
 * `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`. Defaults to `info`.
 * `LOG_FORMAT`: Logging output format, one of `text` or `json`. Defaults to `json`.
 * `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+* `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.

--- a/README_STORE_CONTAINER.md
+++ b/README_STORE_CONTAINER.md
@@ -98,3 +98,4 @@ Although the default settings should work for most environments, a number of set
 * `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`. Defaults to `info`.
 * `LOG_FORMAT`: Logging output format, one of `text` or `json`. Defaults to `json`.
 * `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+* `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.

--- a/_docs/install/docker/index.md
+++ b/_docs/install/docker/index.md
@@ -42,3 +42,4 @@ For most environments, the default settings should work.
 * `LOG_LEVEL`: One of `debug`, `info`, `warning` or `error`.  Defaults to `info`.
 * `LOG_FORMAT`: Logging output format, one of `text` or `json`.  Defaults to `json`.
 * `DISABLE_TELEMETRY`: To disable anonymous usage reporting across the cluster, set to `true`. Defaults to `false`. To help improve the product, data such as API usage and StorageOS configuration information is collected.
+* `DISABLE_ERROR_REPORTING`: To disable error reporting across the cluster, set to `true`. Defaults to `false`. Errors are reported to help identify and resolve potential issues that may occur.


### PR DESCRIPTION
This documents the environment variable added to allow telemetry and error reporting to be enabled/disabled separately.