### PR TITLE
Vagrantfile: restart the containers unless-stopped

### DIFF
--- a/_docs/install/quickstart.md
+++ b/_docs/install/quickstart.md
@@ -35,3 +35,6 @@ Bringing machine 'storageos-3' up with 'virtualbox' provider...
 
 Now you are ready to [manage volumes]({% link _docs/manage/volumes/index.md %})
 or [install Postgres]({% link _docs/applications/databases/postgres.md %}).
+
+__NOTE__: If due to some reason, the storageos containers stop, they can be
+restarted by running `docker start storageos`.

--- a/assets/Vagrantfile
+++ b/assets/Vagrantfile
@@ -4,7 +4,7 @@ $install_storageos = <<SCRIPT
 sudo modprobe nbd nbds_max=1024
 
 # Install StorageOS container
-docker run -d --name storageos \
+docker run -d --restart unless-stopped --name storageos \
     -e HOSTNAME \
     -e ADVERTISE_IP=$1 \
     -e JOIN=192.168.50.100,192.168.50.101,192.168.50.102 \


### PR DESCRIPTION
This change fixes the issue of stopped containers when the VMs are
restarted. The provisioning script, containing the `docker run` command,
is run only when the machine is provisioned for the first time. With
this change, the containers would automatically start when docker
starts.

Also, adds a note about how to start the containers manually.