### PR TITLE
Add explicit clarification for throttle flag.

### DIFF
--- a/_docs/manage/features/index.md
+++ b/_docs/manage/features/index.md
@@ -18,7 +18,7 @@ storage features. No feature labels are present by default.
 | Replication | `storageos.com/replicas`      | integers [0, 5]| Replicates entire volume across nodes. Typically 1 replica is sufficient (2 copies of the data); more than 2 replicas is not recommended. |
 | Failure mode | `storageos.com/failure.mode` | strings [`soft`,`hard`,`alwayson`] | Soft failure mode works together with the failure tolerance. Hard is a mode where any loss in desired replicas count will mark volume as unavailable. AlwaysOn is a mode where as long as master is alive volume will be writable. |
 | Failure tolerance | `storageos.com/failure.tolerance` | integers [0, 4] | Specifies how many failed replicas to tolerate, defaults to (Replicas - 1) if Replicas > 0, so if there are 2 replicas it will default to 1. |
-| QoS         | `storageos.com/throttle`      | true / false   | Deprioritizes traffic by reducing the rate of disk I/O.  |
+| QoS         | `storageos.com/throttle`      | true / false   | Deprioritizes traffic by reducing the rate of disk I/O, when true.  |
 | Placement   | `storageos.com/hint.master`   | Node hostname or uuid   | Requests master volume placement on the specified node.  Will use another node if request can't be satisfied. |
 
 Feature labels are a powerful and flexible way to control storage features,


### PR DESCRIPTION
Even though can be a redundant comment, a clarification clears ambiguity.