### PR TITLE
Fix docker version

### DIFF
--- a/_docs/install/docker/index.md
+++ b/_docs/install/docker/index.md
@@ -13,7 +13,7 @@ Kubernetes 1.7. [**Try it in your browser for up to one hour >>**](https://my.st
 
 ## Prerequisites
 
-It is recommended to use an stable version of [docker](https://docs.docker.com/release-notes/docker-ce/).
+It is recommended to use a stable version of [docker](https://docs.docker.com/release-notes/docker-ce/).
 
 Get a [cluster discovery token]({%link _docs/install/prerequisites/clusterdiscovery.md %})
 ```bash

--- a/_docs/install/docker/index.md
+++ b/_docs/install/docker/index.md
@@ -13,6 +13,8 @@ Kubernetes 1.7. [**Try it in your browser for up to one hour >>**](https://my.st
 
 ## Prerequisites
 
+It is recommended to use an stable version of [docker](https://docs.docker.com/release-notes/docker-ce/).
+
 Get a [cluster discovery token]({%link _docs/install/prerequisites/clusterdiscovery.md %})
 ```bash
 $ storageos cluster create

--- a/_docs/install/prerequisites/index.md
+++ b/_docs/install/prerequisites/index.md
@@ -12,7 +12,7 @@ The following conditions must be met before installing StorageOS:
 1. Minimum one core with 2GB RAM. For replication and HA, a minimum of three nodes is required for quorum.
 1. Linux with a 64-bit architecture
  * For Red Hat Enterprise Linux 7, [read the release notes]({% link _docs/reference/release_notes.md %}).
-1. Docker 1.10 or later
+1. Docker 1.10 or later, preferably `CHANNEL=stable`
 1. The necessary ports should be open. See the [ports and firewall settings]({% link _docs/install/prerequisites/firewalls.md %})
 1. A mechanism for [cluster
 discovery]({% link _docs/install/prerequisites/clusterdiscovery.md %}), to allow

--- a/assets/Vagrantfile
+++ b/assets/Vagrantfile
@@ -1,7 +1,5 @@
 $install_storageos = <<SCRIPT
 
-
-sudo apt-get -y purge docker-ce 
 curl -qS https://get.docker.com/ -o install-docker && chmod +x install-docker
 sudo CHANNEL=stable ./install-docker
 
@@ -39,7 +37,6 @@ image = "bento/ubuntu-16.04"
 
 
 Vagrant.configure("2") do |config|
-  config.vm.provision "docker"
   config.vm.box_check_update = false
   config.vm.box = image
 

--- a/assets/Vagrantfile
+++ b/assets/Vagrantfile
@@ -1,5 +1,10 @@
 $install_storageos = <<SCRIPT
 
+
+sudo apt-get -y purge docker-ce 
+curl -qS https://get.docker.com/ -o install-docker && chmod +x install-docker
+sudo CHANNEL=stable ./install-docker
+
 # Prerequisites
 sudo modprobe nbd nbds_max=1024
 


### PR DESCRIPTION
docker-ce 18.05 (edge channel) breaks shared volumes. We recommend using stable channel and  I forced our Vagrabtfile example to stop using edge.