### PR TITLE
K8s and Openshift documentation

### DIFF
--- a/_docs/install/kubernetes/index.md
+++ b/_docs/install/kubernetes/index.md
@@ -19,18 +19,20 @@ type to install to make devices usable from within containers.
 
 ## Prerequisites
 
-You will need a Kubernetes 1.8+ cluster with Beta APIs enabled.
+You will need a Kubernetes 1.8+ cluster with Beta APIs enabled. The following prerequisites are met by default for Kubernetes 1.10+. 
 
-1. Enable the `MountPropagation` flag by appending `--feature-gates
-MountPropagation=true` to the kube-apiserver and kubelet services.
+1. Make sure your docker installation has mount propagation enabled.
+```
+# A successful run is probe of mount propagation enabled
+docker run -it --rm -v /mnt:/mnt:shared busybox sh -c /bin/date
+```
+1. Enable the `MountPropagation` (the procedure to enable mount propagation flags depends on the cluster's boot procedure):
+ - Append flag `--feature-gates MountPropagation=true` to the deployments kube-apiserver and kube-controller-manager, usually found under `/etc/kubernetes/manifests` in the master node.
+ - Add flag in the kubelet service config `KUBELET_EXTRA_ARGS=--feature-gates=MountPropagation=true`.
 
 1. For deployments where the kubelet runs in a container (eg. [OpenShift]({%link _docs/install/openshift/index.md %}), CoreOS,
 Rancher), add `--volume=/var/lib/storageos:/var/lib/storageos:rshared` to each
 of the kubelets. This will be [fixed](https://github.com/kubernetes/kubernetes/pull/58816) in Kubernetes 1.10+.
-
-1. [Enable the Network Block Device module]({% link
-_docs/install/prerequisites/devicepresentation.md %}) on each node for better
-performance.
 
 For Kubernetes 1.7, you can [install the container directly in
 Docker]({%link _docs/install/docker/index.md %}).

--- a/_docs/install/openshift/index.md
+++ b/_docs/install/openshift/index.md
@@ -18,26 +18,57 @@ type to install to make devices usable from within containers.
 
 You will need an OpenShift 3.8+ cluster with Beta APIs enabled.
 
-1. Enable the `MountPropagation` flag by appending `--feature-gates
-MountPropagation=true` to the kube-apiserver and kubelet services.
+1. Make sure your docker installation has mount propagation enabled.
+```
+# A successful run is proof that mount propagation is enabled
+docker run -it --rm -v /mnt:/mnt:shared busybox sh -c /bin/date
+```
+1. The [iptables rules]({% link _docs/install/prerequisites/firewalls.md %}) required for StorageOS.
+1. Enable the `MountPropagation` flag by appending feature gates to the api and controller (you can apply these changes using the Ansible Playbooks)
+- Add to the KubernetesMasterConfig section (/etc/origin/master/master-config.yaml):
 
-1. If the kubelet is running in a container, add `--volume=/var/lib/storageos:/var/lib/storageos:rshared` to each
-of the kubelets. This will be [fixed](https://github.com/kubernetes/kubernetes/pull/58816) in OpenShift 3.10+.
+    ```
+kubernetesMasterConfig:
+  apiServerArguments:
+    feature-gates:
+    - MountPropagation=true
+  controllerArguments:
+    feature-gates:
+    - MountPropagation=true
+    ```
 
-1. The [iptables rules]({% link
-_docs/install/prerequisites/firewalls.md %}) required for StorageOS.
+- Add to the feature-gates to the kubelet arguments (/etc/origin/node/node-config.yaml):
+
+    ```
+kubeletArguments:
+  feature-gates:
+  - MountPropagation=true
+    ```
+
+- **Warning:** Restarting OpenShift services can cause downtime in the cluster.
+- Restart services in the MasterNode `origin-master-api.service`, `origin-master-controllers.service` and `origin-node.service`
+- Restart service in all Nodes `origin-node.service`
+
 
 For OpenShift 3.7, you can [install the container directly in
 Docker]({%link _docs/install/docker/index.md %}).
 
 ## Install with Helm
 
-Firstly, [install Helm](https://blog.openshift.com/getting-started-helm-openshift).
+StorageOS container needs privileged execution permissions. Because of that it is required to add a security context constraint. 
+
+```bash
+RELEASE=my-release # Name of the release for storageos Chart
+oc --as system:admin create serviceaccount $RELEASE-storageos -n default
+oc --as system:admin adm policy add-scc-to-user privileged system:serviceaccount:default:$RELEASE-storageos
+```
+
+[Install Helm](https://blog.openshift.com/getting-started-helm-openshift)
 
 ```bash
 $ git clone https://github.com/storageos/helm-chart.git storageos
 $ cd storageos
-$ helm install --name my-release .
+$ helm install --name $RELEASE .
 
 # Follow the instructions printed by helm install to update the link between Kubernetes and StorageOS.
 $ ClusterIP=$(kubectl get svc/storageos --namespace kube-system -o custom-columns=IP:spec.clusterIP --no-headers=true)
@@ -48,7 +79,7 @@ $ kubectl patch secret/storageos-api --namespace kube-system --patch "{\"data\":
 To uninstall the release with all related Kubernetes components:
 
 ```bash
-$ helm delete --purge my-release
+$ helm delete --purge $RELEASE
 ```
 
 [See further configuration options.](https://github.com/storageos/helm-chart#configuration)


### PR DESCRIPTION
Documentation regarding shared mounts for k8s and openshift
Add openshift security constraints to install helm chart

Without this documentation, it can be really hard to install these clusters with StorageOS support. 

(I added a reference to the init container for k8s in the lio_support branch)