### PR TITLE
Rename secret to be consistent with Helm chart and tests

### DIFF
--- a/_docs/install/kubernetes/dynamic-provisioning.md
+++ b/_docs/install/kubernetes/dynamic-provisioning.md
@@ -46,7 +46,7 @@ cat > storageos-secret.yaml <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: storageos-secret
+  name: storageos-api
 type: "kubernetes.io/storageos"
 data:
   apiAddress: dGNwOi8vMTI3LjAuMC4xOjU3MDU=
@@ -56,15 +56,15 @@ EOF
 ```
 ```
 kubectl create -f storageos-secret.yaml
-secret "storageos-secret" created
+secret "storageos-api" created
 ```
 
 
 Verify the secret:
 
 ```bash
-kubectl describe secret storageos-secret
-Name:		storageos-secret
+kubectl describe secret storageos-api
+Name:		storageos-api
 Namespace:	default
 Labels:		<none>
 Annotations:	<none>
@@ -124,7 +124,7 @@ parameters:
   description: Kubernetes volume
   fsType: ext4
   adminSecretNamespace: default
-  adminSecretName: storageos-secret
+  adminSecretName: storageos-api
 EOF
 ```
 

--- a/_docs/install/openshift/dynamic-provisioning.md
+++ b/_docs/install/openshift/dynamic-provisioning.md
@@ -46,7 +46,7 @@ cat > storageos-secret.yaml <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: storageos-secret
+  name: storageos-api
 type: "kubernetes.io/storageos"
 data:
   apiAddress: dGNwOi8vMTI3LjAuMC4xOjU3MDU=
@@ -56,14 +56,14 @@ EOF
 ```
 ```
 oc create -f storageos-secret.yaml
-secret "storageos-secret" created
+secret "storageos-api" created
 ```
 
 Verify the secret:
 
 ```bash
-$ oc describe secret storageos-secret
-Name:		storageos-secret
+$ oc describe secret storageos-api
+Name:		storageos-api
 Namespace:	default
 Labels:		<none>
 Annotations:	<none>
@@ -122,7 +122,7 @@ StorageOS supports the following storage class parameters:
    description: Kubernetes volume
    fsType: ext4
    adminSecretNamespace: default
-   adminSecretName: storageos-secret
+   adminSecretName: storageos-api
  ...
  EOF
  ```
@@ -140,7 +140,7 @@ StorageOS supports the following storage class parameters:
  IsDefaultClass: No
  Annotations:    <none>
  Provisioner:    kubernetes.io/storageos
- Parameters:     adminSecretName=storageos-secret,adminSecretNamespace=default,description=Kubernetes volume,fsType=ext4,pool=default
+ Parameters:     adminSecretName=storageos-api,adminSecretNamespace=default,description=Kubernetes volume,fsType=ext4,pool=default
  Events:         <none>
  ```
 
@@ -274,7 +274,7 @@ oc delete pods $(oc get pods |grep ^test-storageos |cut -d' ' -f 1)
 
 oc delete pvc pvc0001 fast0001
 oc delete pv pv0001
-oc delete secret storageos-secret
+oc delete secret storageos-api
 oc delete storageclass fast
 ```
 


### PR DESCRIPTION
Somewhere we started using `storageos-api` as the secret name rather than the original `storageos-secret`.  (e.g. in the Helm chart and demo-env environments).  `storageos-api` seems to make more sense as we now have other secrets for encryption keys.

Updating the examples in the docs to match.  The file name is fine to leave as we use the object type in the other file names (e.g. `storageos-pvc`)