### PR TITLE
Remove nowritecache, label does not pass cp validation

### DIFF
--- a/_docs/manage/features/caching.md
+++ b/_docs/manage/features/caching.md
@@ -32,5 +32,3 @@ or the Docker CLI:
 $ docker volume create --driver storageos --opt size=15 --opt storageos.com/nocache=true volume-name
 volume-name
 ```
-
-To cache reads but not writes, for example when doing backups, set `nowritecache`.


### PR DESCRIPTION
Docs say that you can disable write caching by setting nowritecache.
However, trying to set the volume label results in an error.

```
storageos volume create --label storageos.com/nowritecache=true volume-nowrite-cache
API error (Server failed to process your request. Was the data correct?): cannot use volume label with "storageos.com/" prefix
```