### PR TITLE
Openshift details

### DIFF
--- a/_docs/kubernetes/install-1.8.md
+++ b/_docs/kubernetes/install-1.8.md
@@ -11,9 +11,8 @@ StorageOS requires [mount
 propagation](https://kubernetes.io/docs/concepts/storage/volumes/#mount-propagation)
 in order to present devices as volumes to containers. In Kubernetes 1.8 and 1.9 you need to enable this alpha feature.
 
-* Set `--feature-gates MountPropagation=true` in the kube-apiserver and
-kube-controller-manager deployments, usually found in the master nodes under
-`/etc/kubernetes/manifests`.
+* Set `--feature-gates MountPropagation=true` in the kube-apiserver, usually found in the master nodes under
+`/etc/kubernetes/manifests/kube-apiserver.manifest`.
 * Set `KUBELET_EXTRA_ARGS=--feature-gates=MountPropagation=true` in the kubelet
 service config. For systemd, this usually is located in `/etc/systemd/system/`.
 

--- a/_docs/openshift/install-3.9.md
+++ b/_docs/openshift/install-3.9.md
@@ -10,6 +10,58 @@ module: openshift/install-3.9
 The recommended way to run StorageOS on an OpenShift 3.9+ cluster is to deploy
 a daemonset with RBAC support.
 
+## Prerequisites
+
+You will need an OpenShift cluster with Beta APIs enabled.
+
+1. The [iptables rules]({% link _docs/prerequisites/firewalls.md %}) required for StorageOS.
+1. Make sure your docker installation has mount propagation enabled.
+    ```
+   # A successful run is proof of mount propagation enabled
+   docker run -it --rm -v /mnt:/mnt:shared busybox sh -c /bin/date
+
+   # In case you see the error, docker: Error response from daemon: linux mounts: Could not find source mount of /mnt
+   # you can enable mount propagation by overriding the MountFlag argument
+   mkdir -p /etc/systemd/system/docker.service.d/
+   cat <<EOF > /etc/systemd/system/docker.service.d/mount_propagation_flags.conf
+   [Service]
+   MountFlags=shared
+   EOF
+
+   systemctl daemon-reload
+   systemctl restart docker.service
+    ```
+1. Enable the `MountPropagation` flag by appending feature gates to the api and controller (you can apply these changes using the Ansible Playbooks)
+
+>Note: If you are using atomic installation rather than origin, the location of the yaml config files and service names might change.
+
+- Add to the KubernetesMasterConfig section (/etc/origin/master/master-config.yaml):
+
+    ```bash
+kubernetesMasterConfig:
+  apiServerArguments:
+      feature-gates:
+      - MountPropagation=true
+  controllerArguments:
+      feature-gates:
+      - MountPropagation=true
+    ```
+
+- Add to the feature-gates to the kubelet arguments (/etc/origin/node/node-config.yaml):
+
+    ```bash
+kubeletArguments:
+    feature-gates:
+    - MountPropagation=true
+    ```
+
+- **Warning:** Restarting OpenShift services can cause downtime in the cluster.
+- Restart services in the MasterNode `origin-master-api.service`, `origin-master-controllers.service` and `origin-node.service`
+- Restart service in all Nodes `origin-node.service`
+
+
+## Install StorageOS
+
 ```bash
 git clone https://github.com/storageos/deploy.git storageos
 cd storageos/openshift/deploy-storageos/standard


### PR DESCRIPTION
OpenShift 3.9 installation procedure needs to show how to enable mount propagation for the cluster. 

It is not an easy task to know how to change the cluster configuration.

I added a small fix on the k8s docs as the information was not accurate. 