### PR TITLE
Fix links

### DIFF
--- a/_includes/overview.md
+++ b/_includes/overview.md
@@ -8,9 +8,9 @@ some knowledge of Docker containers and orchestrators.
 _docs/concepts/architecture.md %}) and [playing with a demo](http://play.storageos.com/main).
 
 1. Once you are ready to install on your cluster, make sure the [prerequisites are
-fulfilled]({% link _docs/introduction/quickstart.md %}) and then follow the
+fulfilled]({% link _docs/prerequisites/overview.md %}) and then follow the
 installation guides for [Kubernetes]({% link _docs/kubernetes/install-1.10.md %}),
-[OpenShift]({% link _docs/openshift/install-3.8.md %}) or [Docker]({% link
+[OpenShift]({% link _docs/openshift/install-3.9.md %}) or [Docker]({% link
 _docs/docker/install.md %}).
 
 1. When you want to run StorageOS in production, read about [best practices]({% link


### PR DESCRIPTION
I saw a link pointing to a wrong location and I made sure that the OpenShift installation method by default is 3.9 (as it is the stable release), rather than 3.8 (not production release). 