### PR TITLE
OpenShift 3.10 & 3.11 installation

### DIFF
--- a/_docs/platforms/openshift/install/3.10.md
+++ b/_docs/platforms/openshift/install/3.10.md
@@ -1,12 +1,12 @@
 ---
 layout: guide
-title: StorageOS Docs - Installing on OpenShift 3.9
+title: StorageOS Docs - Installing on OpenShift 3.10
 platform: openshift
 platformUC: Openshift
 cmd: oc
-oc-version: "3.9"
+oc-version: "3.10"
 anchor: platforms
-module: platforms/openshift/install/3.9
+module: platforms/openshift/install/3.10
 ---
 
 {% include platforms/openshift-install.md %}

--- a/_docs/platforms/openshift/install/3.11.md
+++ b/_docs/platforms/openshift/install/3.11.md
@@ -1,12 +1,12 @@
 ---
 layout: guide
-title: StorageOS Docs - Installing on OpenShift 3.9
+title: StorageOS Docs - Installing on OpenShift 3.11
 platform: openshift
 platformUC: Openshift
 cmd: oc
-oc-version: "3.9"
+oc-version: "3.11"
 anchor: platforms
-module: platforms/openshift/install/3.9
+module: platforms/openshift/install/3.11
 ---
 
 {% include platforms/openshift-install.md %}

--- a/_guides/004-platforms.md
+++ b/_guides/004-platforms.md
@@ -69,7 +69,15 @@ sections:
         module: platforms/openshift/install
         subitems:
           -
-            title: 3.9+
+            title: 3.11
+            description: Install on 3.11
+            module: platforms/openshift/install/3.11
+          -
+            title: "3.10"
+            description: Install on 3.10
+            module: platforms/openshift/install/3.10
+          -
+            title: 3.9
             description: Install on 3.9+
             module: platforms/openshift/install/3.9
           -

--- a/_includes/operator/install.md
+++ b/_includes/operator/install.md
@@ -5,10 +5,20 @@ application](https://kubernetes.io/docs/concepts/extend-kubernetes/extend-cluste
 developed to deploy and configure StorageOS clusters, and assist with
 maintenance operations. We recommend its use for standard installations. 
 
-The StorageOS operator can be installed with Helm.
+The operator is a Kubernetes controller that watches the `StorageOSCluster`
+CRD. Once the controller is ready, a StorageOS cluster definition can be
+created. The operator will deploy a StorageOS cluster based on the
+configuration specified in the cluster definition.
 
 ### Install
 
+The StorageOS Cluster Operator can be installed with two options.
+
+* Using Helm
+* Standard yaml manifests
+
+
+### (Option 1) Using Helm
 ```bash
 helm repo add storageos https://charts.storageos.com
 helm install storageos/storageoscluster-operator --namespace storageos-operator
@@ -24,10 +34,32 @@ helm install storageos/storageoscluster-operator --namespace storageos-operator
 > Cluster Operator. You can add the service account to the cluster-admin role
 > for simplicity or create a role that matches the cluster-operator requirements.
 
-The operator is a Kubernetes controller that watches the `StorageOSCluster`
-CRD. Once the controller is ready, a StorageOS cluster definition can be
-created. The operator will deploy a StorageOS cluster based on the
-configuration specified in the cluster definition.
+
+### (Option 2) Standard yaml manifests
+
+{% if page.platform == "openshift" %}
+```bash
+git clone https://github.com/storageos/deploy.git storageos
+cd storageos/openshift/deploy-storageos/cluster-operator
+./deploy-operator.sh
+```
+{% else %}
+```bash
+git clone https://github.com/storageos/deploy.git storageos
+cd storageos/k8s/deploy-storageos/cluster-operator
+./deploy-operator.sh
+```
+{% endif %}
+
+
+### Verify the Cluster Operator Pod
+```bash
+[root@master03]# {{ page.cmd }} -n storageos-operator get pod
+NAME                                         READY     STATUS    RESTARTS   AGE
+storageoscluster-operator-68678798ff-f28zw   1/1       Running   0          3m
+```
+
+> The READY 1/1 indicates that `stos` resources can be created.
 
 ### Create a Secret
 

--- a/_includes/platforms/openshift-install.md
+++ b/_includes/platforms/openshift-install.md
@@ -1,0 +1,72 @@
+# OpenShift {{ page.oc-version }}
+
+The recommended way to run StorageOS on an OpenShift {{ page.oc-version }} cluster is to deploy
+a daemonset with RBAC support.
+
+## Prerequisites
+
+1. Ensure any firewalls permit the [appropriate ports]({% link
+   _docs/prerequisites/firewalls.md %})
+1. If your cluster enables SELinux, add the following permissions for each of
+   the nodes that run StorageOS.
+    ```bash
+setsebool -P virt_sandbox_use_fusefs on
+setsebool -P virt_use_fusefs on
+    ```
+    > The `-P` option makes the change persistent after reboots.
+1. Ensure that your docker installation has mount propagation enabled per our
+   [mount propagation prerequisites]({% link _docs/prerequisites/mountpropagation.md %})
+1. Enable the `MountPropagation` flag by appending feature gates to the api and
+   controller (you can apply these changes using the Ansible Playbooks)
+
+>Note: If you are using atomic installation rather than origin, the location of
+>the yaml config files and service names might change.
+
+- Add to the KubernetesMasterConfig section (/etc/origin/master/master-config.yaml):
+
+    ```bash
+kubernetesMasterConfig:
+  apiServerArguments:
+      feature-gates:
+      - MountPropagation=true
+  controllerArguments:
+      feature-gates:
+      - MountPropagation=true
+    ```
+
+- Add to the feature-gates to the kubelet arguments (/etc/origin/node/node-config.yaml):
+
+    ```bash
+kubeletArguments:
+    feature-gates:
+    - MountPropagation=true
+    ```
+
+>  **Warning:** Restarting OpenShift services can cause downtime in the cluster.
+{% if page.oc-version == '3.10' or page.oc-version == '3.11' %}
+- Restart services in the MasterNode/s
+    ```bash
+master-restart api
+master-restart controllers
+
+  # Restart kubelet
+systemctl restart atomic-openshift-node.service
+   ```
+
+- Restart service in all Nodes 
+   ```bash
+# Restart kubelet
+systemctl restart atomic-openshift-node.service
+    ```
+{% else %}
+- Restart services in the MasterNode `origin-master-api.service`,
+  `origin-master-controllers.service` and `origin-node.service`
+- Restart service in all Nodes `origin-node.service`
+
+> Usually through `systemctl restart (origin-node.service|atomic-openshift-node.service)`
+{% endif %}
+
+
+{% include operator/install.md %}
+
+{% include k8s/custom-install.md %}


### PR DESCRIPTION
- Openshift 3.10 and 3.11
- Cluster Operator without Helm
- SELinux prerequisite for 3.9, 3.10 and 3.11