### PR TITLE
Add StorageOS operator label example

### DIFF
--- a/_includes/troubleshoot/issues/join-to-master-node.md
+++ b/_includes/troubleshoot/issues/join-to-master-node.md
@@ -46,5 +46,15 @@ you are using the discovery service, it is necessary to ensure that the
 DaemonSet won't allocate Pods on the masters. This can be achieved with taints,
 node selectors or labels.
 
-An [example of deployment](https://github.com/storageos/deploy/tree/master/k8s/deploy-storageos/labeled-deployment)
-is available to see how to run StorageOS with node labels.
+For installations with the StorageOS operator you can specify which nodes to
+deploy StorageOS on using {% if page.platform == "OpenShift" %}[node
+labels.](https://github.com/storageos/deploy/tree/master/openshift/deploy-storageos/cluster-operator#select-nodes-where-storageos-will-deploy)
+{% else %}[node
+labels.](https://github.com/storageos/deploy/tree/master/k8s/deploy-storageos/cluster-operator#select-nodes-where-storageos-will-deploy)
+{% endif %}
+
+{% if page.platform == "Kubernetes" %} For more advanced installations using
+compute-only and storage nodes our [example
+deployment](https://github.com/storageos/deploy/tree/master/k8s/deploy-storageos/labeled-deployment)
+is available as an example of how to run StorageOS with node labels. {% else
+%}{% endif %}


### PR DESCRIPTION
The purpose of this PR is to clarify how to use node labels with openshift and k8s using the operator. The reason I've opened this PR is that previously it linked to a much more advanced deployment example that was unnecessary. 

In the current state of this PR there's no advanced label deployment for OpenShift so I have excluded any mention of it for OS. My thinking is that we create an advanced label deployment for OpenShift and then amend the docs. 

It might also be preferable to link to https://docs.storageos.com/docs/reference/cluster-operator/examples instead of the Github deploy repository. 