### PR TITLE
operator/install: Add SCC for statefulset

### DIFF
--- a/_includes/operator/install.md
+++ b/_includes/operator/install.md
@@ -95,6 +95,7 @@ unique, strong password.
 
 ```bash
 oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-daemonset-sa
+oc adm policy add-scc-to-user privileged system:serviceaccount:storageos:storageos-statefulset-sa
 ```
 {% endif %}
 


### PR DESCRIPTION
The statefulset service account also needs privilege to use the volume hostpath in the CSI sidecar containers.