### PR TITLE
Ubuntu bionic and later use linux-modules-extra

### DIFF
--- a/_docs/prerequisites/systemconfiguration.md
+++ b/_docs/prerequisites/systemconfiguration.md
@@ -28,9 +28,18 @@ installation.
 
 **Ubuntu 16.04/18.04 Generic** and **Ubuntu 16.04 GCE** require extra packages:
 
+Ubuntu 16.04:
+
 ```bash
 sudo apt -y update
 sudo apt -y install linux-image-extra-$(uname -r)
+```
+
+Ubuntu 18.04+:
+
+```bash
+sudo apt -y update
+sudo apt -y install linux-modules-extra-$(uname -r)
 ```
 
 **Ubuntu 16.04/18.04 AWS** and **Ubuntu 18.04 GCE** do not yet provide the


### PR DESCRIPTION
linux-modules-extra is only in the xenial package repo.  For bionic, the package is called linux-modules-extra.  tcm_loop.ko is in https://packages.ubuntu.com/bionic/all/linux-modules-extra-4.15.0-20-generic.