### PR TITLE
Update prometheus-setup doc link to use git tag

### DIFF
--- a/_docs/reference/release_notes.md
+++ b/_docs/reference/release_notes.md
@@ -1588,5 +1588,5 @@ growing suite of platforms and usage scenarios.
 
 [cluster-operator]: https://docs.storageos.com/docs/reference/cluster-operator
 [prometheus-operator]: https://github.com/coreos/prometheus-operator
-[prometheus-setup]: https://github.com/storageos/cluster-operator/tree/master/docs/operator-prometheus-metrics
+[prometheus-setup]: https://github.com/storageos/cluster-operator/tree/1.5.1/docs/operator-prometheus-metrics
 [leader-election]: https://github.com/operator-framework/operator-sdk/blob/master/doc/user-guide.md#leader-election


### PR DESCRIPTION
The docs may move or be renamed in the future and the link will break. Use a git tag link to avoid broken links.