### PR TITLE
Fix helm install procedure link

### DIFF
--- a/_docs/prerequisites/overview.md
+++ b/_docs/prerequisites/overview.md
@@ -25,7 +25,7 @@ One machine with the following:
 1. [Install the storageos CLI]({% link _docs/reference/cli/index.md %}).
 1. If using Helm, make sure the tiller ServiceAccount has enough privileges to
    create resources such as Namespaces, ClusterRoles, etc. For instance, following this [installation
-   procedure](https://github.com/helm/helm/blob/master/docs/rbac.md#example-service-account-with-cluster-admin-role).
+   procedure](https://v2.helm.sh/docs/rbac/#example-service-account-with-cluster-admin-role).
 1. System clocks synchronized using NTP or similar methods. While our
    distributed consensus algorithm does not require synchronised clocks, it
    does help to more easily correlate logs across multiple nodes.


### PR DESCRIPTION
Use document link from helm v2 website.
The referred doc is removed from the master branch (helm v3). Use doc link from helm v2 release website.